### PR TITLE
Create DataSource and Dashboard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ RUN make build
 FROM busybox
 COPY --from=builder /build/grafana-organizations-operator /
 COPY --from=alpine:latest /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY default-dashboard.json /
 CMD ["/grafana-organizations-operator"]

--- a/default-dashboard.json
+++ b/default-dashboard.json
@@ -1,0 +1,509 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 15,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "dA9pr1U4z"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "dA9pr1U4z"
+          },
+          "editorMode": "builder",
+          "expr": "max by(namespace, pod) (container_memory_working_set_bytes{namespace=~\"$namespace\", container!=\"\", image!=\"\"})",
+          "legendFormat": "{{namespace}}: {{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "dA9pr1U4z"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "dA9pr1U4z"
+          },
+          "editorMode": "builder",
+          "expr": "max by(namespace, pod) (rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "{{namespace}}: {{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "dA9pr1U4z"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "dA9pr1U4z"
+          },
+          "editorMode": "builder",
+          "expr": "max by(namespace, persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"$namespace\"})",
+          "legendFormat": "{{namespace}}: {{persistentvolumeclaim}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Disk Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "dA9pr1U4z"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "dA9pr1U4z"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "max by(namespace, deployment) (kube_deployment_status_replicas_unavailable{namespace=~\"$namespace\"})",
+          "interval": "",
+          "legendFormat": "{{namespace}}: {{deployment}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Replicas Unavailable",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "ahaas-test",
+            "appuio-openshift4-slos",
+            "beck-test",
+            "bigli-test",
+            "cha-test2",
+            "colin-test",
+            "foo",
+            "glrf-grafana-test",
+            "glrf-test",
+            "lagoon-harbor",
+            "mhu-otto-appcat",
+            "monitoring-example",
+            "openshift-ingress-operator",
+            "paralus-system",
+            "sg-test",
+            "sobrado-dev",
+            "sobrado-konf-dev",
+            "sobrado-konf-prod",
+            "swi-test",
+            "vshn-dagobert",
+            "vshn-demo-fortune",
+            "vshn-keycloak-dev",
+            "vshn-postgresql-buzz-qvgrd",
+            "vshn-postgresql-widera-test-8ftjt",
+            "vshn-redis-redis-test-cr7vj",
+            "vshn-vcluster-dev",
+            "widera-testing"
+          ],
+          "value": [
+            "ahaas-test",
+            "appuio-openshift4-slos",
+            "beck-test",
+            "bigli-test",
+            "cha-test2",
+            "colin-test",
+            "foo",
+            "glrf-grafana-test",
+            "glrf-test",
+            "lagoon-harbor",
+            "mhu-otto-appcat",
+            "monitoring-example",
+            "openshift-ingress-operator",
+            "paralus-system",
+            "sg-test",
+            "sobrado-dev",
+            "sobrado-konf-dev",
+            "sobrado-konf-prod",
+            "swi-test",
+            "vshn-dagobert",
+            "vshn-demo-fortune",
+            "vshn-keycloak-dev",
+            "vshn-postgresql-buzz-qvgrd",
+            "vshn-postgresql-widera-test-8ftjt",
+            "vshn-redis-redis-test-cr7vj",
+            "vshn-vcluster-dev",
+            "widera-testing"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "dA9pr1U4z"
+        },
+        "definition": "label_values(namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Base Metrics",
+  "uid": "eorIRxUVz",
+  "version": 19,
+  "weekStart": ""
+}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   grafana:
-    image: grafana/grafana-oss:9.5.1
+    image: grafana/grafana-oss:9.5.2
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=$GF_SECURITY_ADMIN_PASSWORD
     ports:

--- a/pkg/dashboard.go
+++ b/pkg/dashboard.go
@@ -1,0 +1,55 @@
+package controller
+
+import (
+	"errors"
+	"fmt"
+	grafana "github.com/grafana/grafana-api-golang-client"
+)
+
+func configureDashboard(dashboardModel map[string]interface{}, dataSource *grafana.DataSource) error {
+	var dataSourceMap = make(map[string]string)
+	dataSourceMap["type"] = dataSource.Type
+	dataSourceMap["uid"] = dataSource.UID
+
+	delete(dashboardModel, "id")
+	delete(dashboardModel, "uid")
+	delete(dashboardModel, "version")
+	delete(dashboardModel, "time")
+
+	if panels, ok := dashboardModel["panels"]; ok {
+		panelsArray, ok := panels.([]interface{})
+		if !ok {
+			return errors.New("Invalid dashboard format: 'panels' does not contain array")
+		}
+		for i, panel := range panelsArray {
+			panelMap, ok := panel.(map[string]interface{})
+			if !ok {
+				return errors.New(fmt.Sprintf("Invalid dashboard format: 'panels[%d]' is not a map", i))
+			}
+			panelMap["datasource"] = dataSourceMap
+		}
+	}
+
+	if templating, ok := dashboardModel["templating"]; ok {
+		templatingMap, ok := templating.(map[string]interface{})
+		if !ok {
+			return errors.New("Invalid dashboard format: 'templating' does not contain map")
+		}
+		if templatingList, ok := templatingMap["list"]; ok {
+			templatingListArray, ok := templatingList.([]interface{})
+			if !ok {
+				return errors.New("Invalid dashboard format: 'templating.list' does not contain array")
+			}
+			for i, template := range templatingListArray {
+				templateMap, ok := template.(map[string]interface{})
+				if !ok {
+					return errors.New(fmt.Sprintf("Invalid dashboard format: 'templating.list[%d]' is not a map", i))
+				}
+				templateMap["datasource"] = dataSourceMap
+				delete(templateMap, "current")
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/reconcile.go
+++ b/pkg/reconcile.go
@@ -2,40 +2,171 @@ package controller
 
 import (
 	"context"
+	"errors"
 	orgs "github.com/appuio/control-api/apis/organization/v1"
 	grafana "github.com/grafana/grafana-api-golang-client"
 	"github.com/hashicorp/go-cleanhttp"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+	"reflect"
 	"strings"
 )
 
-func reconcileOrg(grafanaOrgLookup map[string]grafana.Org, grafanaClient *grafana.Client, o orgs.Organization) error {
-	displayName := o.Name
-	if o.Spec.DisplayName != "" {
-		displayName = o.Spec.DisplayName
+func reconcileOrgSettings(org *grafana.Org, orgName string, config grafana.Config, url string, dashboard map[string]interface{}) error {
+	// We can't use the grafanaClient from the overarching reconciliation loop because that client doesn't have the X-Grafana-Org-Id header set.
+	// It appears that the only way to set that header is to create a new client instance.
+	config.Client = cleanhttp.DefaultPooledClient()
+	config.OrgID = org.ID
+	grafanaClient, err := grafana.New(url, config)
+	if err != nil {
+		return err
 	}
-	grafanaOrgName := o.Name + " - " + displayName
+	defer config.Client.CloseIdleConnections()
+	dataSource, err := reconcileOrgDataSource(org, orgName, grafanaClient)
+	if err != nil {
+		return err
+	}
+	err = reconcileOrgDashboard(org, dataSource, grafanaClient, dashboard)
+	if err != nil {
+		return err
+	}
+	klog.Infof("Organization %d OK", org.ID)
+	return nil
+}
 
-	if grafanaOrg, ok := grafanaOrgLookup[o.Name]; ok {
-		if grafanaOrg.Name != grafanaOrgName {
-			klog.Infof("Grafana organization %d has wrong name: '%s', should be '%s'\n", grafanaOrg.ID, grafanaOrg.Name, grafanaOrgName)
-			err := grafanaClient.UpdateOrg(grafanaOrg.ID, grafanaOrgName)
-			if err != nil {
-				return err
-			}
+func reconcileOrgDashboard(org *grafana.Org, dataSource *grafana.DataSource, client *grafana.Client, dashboardModel map[string]interface{}) error {
+	dashboardTitle, ok := dashboardModel["title"]
+	if !ok {
+		errors.New("Invalid dashboard format: 'title' key not found")
+	}
+
+	dashboards, err := client.Dashboards()
+	if err != nil {
+		return err
+	}
+	for _, dashboard := range dashboards {
+		if dashboardTitle == dashboard.Title {
+			// Dashboard with this title already exists. We don't try to "fix" the dashboards for now, as this can cause various issues.
+			//klog.Infof("Grafana organization %d already has dashboard '%s'", org.ID, dashboardTitle)
+			return nil
 		}
-	} else {
-		klog.Infof("Grafana organization missing, creating: '%s'\n", grafanaOrgName)
-		_, err := grafanaClient.NewOrg(grafanaOrgName)
-		if err != nil {
-			return err
-		}
+	}
+
+	err = configureDashboard(dashboardModel, dataSource)
+	if err != nil {
+		return err
+	}
+
+	dashboard := grafana.Dashboard{
+		Model:     dashboardModel,
+		Overwrite: true,
+	}
+	klog.Infof("Creating dashboard '%s' for organization %d", dashboardTitle, org.ID)
+	_, err = client.NewDashboard(dashboard)
+	if err != nil {
+		return err
 	}
 	return nil
 }
 
-func ReconcileAllOrgs(ctx context.Context, controlApiClient *rest.RESTClient, grafanaConfig grafana.Config, grafanaUrl string) error {
+func reconcileOrgDataSource(org *grafana.Org, orgName string, client *grafana.Client) (*grafana.DataSource, error) {
+	// If you add/remove fields here you must also adjust the 'if' statement further down
+	desiredDataSource := &grafana.DataSource{
+		Name:      "Mimir",
+		URL:       "http://vshn-appuio-mimir-query-frontend.vshn-appuio-mimir.svc.cluster.local:8080/prometheus",
+		OrgID:     org.ID, // doesn't actually do anything, we just keep it here in case it becomes relevant with some never version of the client library. The actual orgId is taken from the 'X-Grafana-Org-Id' HTTP header which is set up via grafanaConfig.OrgID
+		Type:      "prometheus",
+		IsDefault: true,
+		JSONData: map[string]interface{}{
+			"httpHeaderName1": "X-Scope-OrgID",
+			"httpMethod":      "POST",
+			"prometheusType":  "Mimir",
+		},
+		SecureJSONData: map[string]interface{}{
+			"httpHeaderValue1": orgName,
+		},
+		Access: "proxy",
+	}
+
+	var configuredDataSource *grafana.DataSource
+	configuredDataSource = nil
+	dataSources, err := client.DataSources()
+	if err != nil {
+		return nil, err
+	}
+	if len(dataSources) > 0 {
+		for _, dataSource := range dataSources {
+			if dataSource.Name == desiredDataSource.Name {
+				if dataSource.URL != desiredDataSource.URL ||
+					dataSource.Type != desiredDataSource.Type ||
+					dataSource.IsDefault != desiredDataSource.IsDefault ||
+					!reflect.DeepEqual(dataSource.JSONData, desiredDataSource.JSONData) ||
+					dataSource.Access != desiredDataSource.Access {
+					klog.Infof("Organization %d has misconfigured data source, fixing", org.ID)
+					desiredDataSource.ID = dataSource.ID
+					desiredDataSource.UID = dataSource.UID
+					err := client.UpdateDataSource(desiredDataSource)
+					if err != nil {
+						return nil, err
+					}
+					configuredDataSource = desiredDataSource
+				} else {
+					configuredDataSource = dataSource
+				}
+			} else {
+				klog.Infof("Organization %d has invalid data source %d %s, removing", org.ID, dataSource.ID, dataSource.Name)
+				client.DeleteDataSource(dataSource.ID)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	if configuredDataSource == nil {
+		klog.Infof("Organization %d missing data source, creating", org.ID)
+		dataSourceId, err := client.NewDataSource(desiredDataSource)
+		if err != nil {
+			return nil, err
+		}
+		configuredDataSource, err = client.DataSource(dataSourceId)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return configuredDataSource, nil
+}
+
+func reconcileOrgBasic(grafanaOrgLookup map[string]grafana.Org, grafanaClient *grafana.Client, o orgs.Organization) (*grafana.Org, error) {
+	displayName := o.Name
+	if o.Spec.DisplayName != "" {
+		displayName = o.Spec.DisplayName
+	}
+	grafanaOrgDesiredName := o.Name + " - " + displayName
+
+	if grafanaOrg, ok := grafanaOrgLookup[o.Name]; ok {
+		if grafanaOrg.Name != grafanaOrgDesiredName {
+			klog.Infof("Organization %d has wrong name: '%s', should be '%s'", grafanaOrg.ID, grafanaOrg.Name, grafanaOrgDesiredName)
+			err := grafanaClient.UpdateOrg(grafanaOrg.ID, grafanaOrgDesiredName)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return &grafanaOrg, nil
+	}
+
+	klog.Infof("Organization missing, creating: '%s'", grafanaOrgDesiredName)
+	grafanaOrgId, err := grafanaClient.NewOrg(grafanaOrgDesiredName)
+	if err != nil {
+		return nil, err
+	}
+	grafanaOrg, err := grafanaClient.Org(grafanaOrgId)
+	if err != nil {
+		return nil, err
+	}
+	return &grafanaOrg, nil
+}
+
+func ReconcileAllOrgs(ctx context.Context, controlApiClient *rest.RESTClient, grafanaConfig grafana.Config, grafanaUrl string, dashboard map[string]interface{}) error {
 	grafanaConfig.Client = cleanhttp.DefaultPooledClient()
 	grafanaClient, err := grafana.New(grafanaUrl, grafanaConfig)
 	if err != nil {
@@ -55,7 +186,6 @@ func ReconcileAllOrgs(ctx context.Context, controlApiClient *rest.RESTClient, gr
 	}
 
 	grafanaOrgLookup := make(map[string]grafana.Org)
-
 	for _, org := range orgs {
 		nameComponents := strings.Split(org.Name, " - ")
 		if len(nameComponents) < 2 || strings.Contains(nameComponents[0], " ") {
@@ -65,11 +195,16 @@ func ReconcileAllOrgs(ctx context.Context, controlApiClient *rest.RESTClient, gr
 	}
 
 	for _, o := range appuioControlApiOrgs.Items {
-		err = reconcileOrg(grafanaOrgLookup, grafanaClient, o)
+		grafanaOrg, err := reconcileOrgBasic(grafanaOrgLookup, grafanaClient, o)
 		if err != nil {
 			return err
 		}
 		delete(grafanaOrgLookup, o.Name)
+
+		err = reconcileOrgSettings(grafanaOrg, o.Name, grafanaConfig, grafanaUrl, dashboard)
+		if err != nil {
+			return err
+		}
 
 		// select with a default case is apparently the only way to do a non-blocking read from a channel
 		select {
@@ -81,12 +216,19 @@ func ReconcileAllOrgs(ctx context.Context, controlApiClient *rest.RESTClient, gr
 	}
 
 	for _, grafanaOrgToBeDeleted := range grafanaOrgLookup {
-		klog.Infof("Grafana organization %d should not exist, deleting: '%s'\n", grafanaOrgToBeDeleted.ID, grafanaOrgToBeDeleted.Name)
+		klog.Infof("Organization %d should not exist, deleting: '%s'", grafanaOrgToBeDeleted.ID, grafanaOrgToBeDeleted.Name)
 		err = grafanaClient.DeleteOrg(grafanaOrgToBeDeleted.ID)
 		if err != nil {
 			return err
 		}
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
 	}
+
+	klog.Infof("Reconcile complete")
 
 	return nil
 }


### PR DESCRIPTION
This change adds functionality to set up a datasource and a basic dashboard.

This requires some changes to the architecture. In particular multiple client instances are required; a general one for setting up the empty orgs, and then one client instance per org. This is because of the grafana API's weird org ID handling (must be supplied via HTTP header) and limitations of the API client (HTTP header can only be set by creating a new client instance).