### PR TITLE
Add: Functionality to sync users and set their organization permissions

### DIFF
--- a/pkg/controlApi.go
+++ b/pkg/controlApi.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	"context"
+	orgs "github.com/appuio/control-api/apis/organization/v1"
+	controlapi "github.com/appuio/control-api/apis/v1"
+	grafana "github.com/grafana/grafana-api-golang-client"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+)
+
+// Generate list of control API organizations
+func getControlApiOrganizations(ctx context.Context, organizationAppuioIoClient *rest.RESTClient) ([]orgs.Organization, error) {
+	controlApiOrgs := orgs.OrganizationList{}
+	err := organizationAppuioIoClient.Get().Resource("Organizations").Do(ctx).Into(&controlApiOrgs)
+	if err != nil {
+		return nil, err
+	}
+	controlApiOrgsList := []orgs.Organization{}
+	for _, org := range controlApiOrgs.Items {
+		controlApiOrgsList = append(controlApiOrgsList, org)
+	}
+	return controlApiOrgsList, nil
+}
+
+// Generate map containing all control API users. Key is the user ID, value is the user object.
+func getControlApiUsersMap(ctx context.Context, appuioIoClient *rest.RESTClient) (map[string]controlapi.User, error) {
+	controlApiUsers := controlapi.UserList{}
+	err := appuioIoClient.Get().Resource("Users").Do(ctx).Into(&controlApiUsers)
+	if err != nil {
+		return nil, err
+	}
+	appuioControlApiUsersMap := make(map[string]controlapi.User)
+	for _, user := range controlApiUsers.Items {
+		appuioControlApiUsersMap[user.Name] = user
+	}
+	return appuioControlApiUsersMap, nil
+}
+
+// Generate map containing all Grafana users grouped by organization. Key is the organization ID, value is an array of users.
+func getControlApiOrganizationUsersMap(ctx context.Context, grafanaUsersMap map[string]grafana.User, appuioIoClient *rest.RESTClient) (map[string][]grafana.User, error) {
+	appuioControlApiOrganizationMembers := controlapi.OrganizationMembersList{}
+	err := appuioIoClient.Get().Resource("OrganizationMembers").Do(ctx).Into(&appuioControlApiOrganizationMembers)
+	if err != nil {
+		return nil, err
+	}
+	controlApiOrganizationUsersMap := make(map[string][]grafana.User)
+	for _, memberlist := range appuioControlApiOrganizationMembers.Items {
+		users := []grafana.User{}
+		for _, userRef := range memberlist.Spec.UserRefs {
+			if grafanaUser, ok := grafanaUsersMap[userRef.Name]; ok {
+				users = append(users, grafanaUser)
+			} else {
+				klog.Warningf("Organization '%s' should have user %s but the user wasn't synced to Grafana, ignoring", memberlist.Namespace, userRef.Name)
+			}
+		}
+		controlApiOrganizationUsersMap[memberlist.Namespace] = users
+	}
+	return controlApiOrganizationUsersMap, nil
+}

--- a/pkg/reconcile.go
+++ b/pkg/reconcile.go
@@ -2,140 +2,112 @@ package controller
 
 import (
 	"context"
-	"errors"
 	orgs "github.com/appuio/control-api/apis/organization/v1"
 	grafana "github.com/grafana/grafana-api-golang-client"
 	"github.com/hashicorp/go-cleanhttp"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
-	"reflect"
 	"strings"
 )
 
-func reconcileOrgSettings(org *grafana.Org, orgName string, config grafana.Config, url string, dashboard map[string]interface{}) error {
-	// We can't use the grafanaClient from the overarching reconciliation loop because that client doesn't have the X-Grafana-Org-Id header set.
-	// It appears that the only way to set that header is to create a new client instance.
-	config.Client = cleanhttp.DefaultPooledClient()
-	config.OrgID = org.ID
-	grafanaClient, err := grafana.New(url, config)
+func ReconcileAllOrgs(ctx context.Context, organizationAppuioIoClient *rest.RESTClient, appuioIoClient *rest.RESTClient, grafanaConfig grafana.Config, grafanaUrl string, dashboard map[string]interface{}) error {
+	// Fetch everything we need from the control API.
+	// This is racy because data can change while we fetch it, making the result inconsistent. This may lead to sync errors,
+	// but they should disappear with subsequent syncs.
+	controlApiOrganizationsList, err := getControlApiOrganizations(ctx, organizationAppuioIoClient)
 	if err != nil {
 		return err
 	}
-	defer config.Client.CloseIdleConnections()
-	dataSource, err := reconcileOrgDataSource(org, orgName, grafanaClient)
+	controlApiUsersMap, err := getControlApiUsersMap(ctx, appuioIoClient)
 	if err != nil {
 		return err
-	}
-	err = reconcileOrgDashboard(org, dataSource, grafanaClient, dashboard)
-	if err != nil {
-		return err
-	}
-	klog.Infof("Organization %d OK", org.ID)
-	return nil
-}
-
-func reconcileOrgDashboard(org *grafana.Org, dataSource *grafana.DataSource, client *grafana.Client, dashboardModel map[string]interface{}) error {
-	dashboardTitle, ok := dashboardModel["title"]
-	if !ok {
-		errors.New("Invalid dashboard format: 'title' key not found")
 	}
 
-	dashboards, err := client.Dashboards()
+	// Generic Grafana client, not specific to an org (deeper down we'll also create an org-specific Grafana client)
+	grafanaConfig.Client = cleanhttp.DefaultPooledClient()
+	grafanaClient, err := grafana.New(grafanaUrl, grafanaConfig)
 	if err != nil {
 		return err
 	}
-	for _, dashboard := range dashboards {
-		if dashboardTitle == dashboard.Title {
-			// Dashboard with this title already exists. We don't try to "fix" the dashboards for now, as this can cause various issues.
-			//klog.Infof("Grafana organization %d already has dashboard '%s'", org.ID, dashboardTitle)
+	defer grafanaConfig.Client.CloseIdleConnections()
+
+	// Get all orgs from Grafana
+	orgs, err := grafanaClient.Orgs()
+	if err != nil {
+		return err
+	}
+
+	// Users are a top-level resource, like organizations. Users can exist even if they don't have permissions to do anything.
+	grafanaUsersMap, err := reconcileUsers(grafanaClient, controlApiUsersMap)
+	if err != nil {
+		return err
+	}
+
+	// Lookup table org -> users (editors or viewers)
+	appuioControlApiOrganizationUsersMap, err := getControlApiOrganizationUsersMap(ctx, grafanaUsersMap, appuioIoClient)
+	if err != nil {
+		return err
+	}
+
+	// List of admin users (for now this is equivalent to all users of the "vshn" org). The same for all orgs.
+	var desiredAdmins []grafana.User
+	var ok bool
+	if desiredAdmins, ok = appuioControlApiOrganizationUsersMap["vshn"]; !ok {
+		desiredAdmins = []grafana.User{}
+	}
+
+	// Lookup table org ID (the one from the control API, type string) -> Grafana org
+	grafanaOrgLookup := make(map[string]grafana.Org)
+	for _, org := range orgs {
+		nameComponents := strings.Split(org.Name, " - ")
+		if len(nameComponents) < 2 || strings.Contains(nameComponents[0], " ") {
+			continue
+		}
+		grafanaOrgLookup[nameComponents[0]] = org
+	}
+
+	// first make sure that all orgs that need to be present are present
+	for _, o := range controlApiOrganizationsList {
+		grafanaOrg, err := reconcileOrgBasic(grafanaOrgLookup, grafanaClient, o)
+		if err != nil {
+			return err
+		}
+		delete(grafanaOrgLookup, o.Name)
+
+		err = reconcileOrgSettings(grafanaOrg, o.Name, grafanaConfig, grafanaUrl, dashboard, appuioControlApiOrganizationUsersMap[o.Name], desiredAdmins)
+		if err != nil {
+			return err
+		}
+
+		// select with a default case is apparently the only way to do a non-blocking read from a channel
+		select {
+		case <-ctx.Done():
 			return nil
+		default:
+			// carry on
 		}
 	}
 
-	err = configureDashboard(dashboardModel, dataSource)
-	if err != nil {
-		return err
+	// then delete the ones that shouldn't be present
+	for _, grafanaOrgToBeDeleted := range grafanaOrgLookup {
+		klog.Infof("Organization %d should not exist, deleting: '%s'", grafanaOrgToBeDeleted.ID, grafanaOrgToBeDeleted.Name)
+		err = grafanaClient.DeleteOrg(grafanaOrgToBeDeleted.ID)
+		if err != nil {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
 	}
 
-	dashboard := grafana.Dashboard{
-		Model:     dashboardModel,
-		Overwrite: true,
-	}
-	klog.Infof("Creating dashboard '%s' for organization %d", dashboardTitle, org.ID)
-	_, err = client.NewDashboard(dashboard)
-	if err != nil {
-		return err
-	}
+	klog.Infof("Reconcile complete")
+
 	return nil
 }
 
-func reconcileOrgDataSource(org *grafana.Org, orgName string, client *grafana.Client) (*grafana.DataSource, error) {
-	// If you add/remove fields here you must also adjust the 'if' statement further down
-	desiredDataSource := &grafana.DataSource{
-		Name:      "Mimir",
-		URL:       "http://vshn-appuio-mimir-query-frontend.vshn-appuio-mimir.svc.cluster.local:8080/prometheus",
-		OrgID:     org.ID, // doesn't actually do anything, we just keep it here in case it becomes relevant with some never version of the client library. The actual orgId is taken from the 'X-Grafana-Org-Id' HTTP header which is set up via grafanaConfig.OrgID
-		Type:      "prometheus",
-		IsDefault: true,
-		JSONData: map[string]interface{}{
-			"httpHeaderName1": "X-Scope-OrgID",
-			"httpMethod":      "POST",
-			"prometheusType":  "Mimir",
-		},
-		SecureJSONData: map[string]interface{}{
-			"httpHeaderValue1": orgName,
-		},
-		Access: "proxy",
-	}
-
-	var configuredDataSource *grafana.DataSource
-	configuredDataSource = nil
-	dataSources, err := client.DataSources()
-	if err != nil {
-		return nil, err
-	}
-	if len(dataSources) > 0 {
-		for _, dataSource := range dataSources {
-			if dataSource.Name == desiredDataSource.Name {
-				if dataSource.URL != desiredDataSource.URL ||
-					dataSource.Type != desiredDataSource.Type ||
-					dataSource.IsDefault != desiredDataSource.IsDefault ||
-					!reflect.DeepEqual(dataSource.JSONData, desiredDataSource.JSONData) ||
-					dataSource.Access != desiredDataSource.Access {
-					klog.Infof("Organization %d has misconfigured data source, fixing", org.ID)
-					desiredDataSource.ID = dataSource.ID
-					desiredDataSource.UID = dataSource.UID
-					err := client.UpdateDataSource(desiredDataSource)
-					if err != nil {
-						return nil, err
-					}
-					configuredDataSource = desiredDataSource
-				} else {
-					configuredDataSource = dataSource
-				}
-			} else {
-				klog.Infof("Organization %d has invalid data source %d %s, removing", org.ID, dataSource.ID, dataSource.Name)
-				client.DeleteDataSource(dataSource.ID)
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
-	}
-	if configuredDataSource == nil {
-		klog.Infof("Organization %d missing data source, creating", org.ID)
-		dataSourceId, err := client.NewDataSource(desiredDataSource)
-		if err != nil {
-			return nil, err
-		}
-		configuredDataSource, err = client.DataSource(dataSourceId)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return configuredDataSource, nil
-}
-
+// Sync the basic org. Uses the generic Grafana client.
 func reconcileOrgBasic(grafanaOrgLookup map[string]grafana.Org, grafanaClient *grafana.Client, o orgs.Organization) (*grafana.Org, error) {
 	displayName := o.Name
 	if o.Spec.DisplayName != "" {
@@ -164,71 +136,4 @@ func reconcileOrgBasic(grafanaOrgLookup map[string]grafana.Org, grafanaClient *g
 		return nil, err
 	}
 	return &grafanaOrg, nil
-}
-
-func ReconcileAllOrgs(ctx context.Context, controlApiClient *rest.RESTClient, grafanaConfig grafana.Config, grafanaUrl string, dashboard map[string]interface{}) error {
-	grafanaConfig.Client = cleanhttp.DefaultPooledClient()
-	grafanaClient, err := grafana.New(grafanaUrl, grafanaConfig)
-	if err != nil {
-		return err
-	}
-	defer grafanaConfig.Client.CloseIdleConnections()
-
-	appuioControlApiOrgs := orgs.OrganizationList{}
-	err = controlApiClient.Get().Resource("Organizations").Do(ctx).Into(&appuioControlApiOrgs)
-	if err != nil {
-		return err
-	}
-
-	orgs, err := grafanaClient.Orgs()
-	if err != nil {
-		return err
-	}
-
-	grafanaOrgLookup := make(map[string]grafana.Org)
-	for _, org := range orgs {
-		nameComponents := strings.Split(org.Name, " - ")
-		if len(nameComponents) < 2 || strings.Contains(nameComponents[0], " ") {
-			continue
-		}
-		grafanaOrgLookup[nameComponents[0]] = org
-	}
-
-	for _, o := range appuioControlApiOrgs.Items {
-		grafanaOrg, err := reconcileOrgBasic(grafanaOrgLookup, grafanaClient, o)
-		if err != nil {
-			return err
-		}
-		delete(grafanaOrgLookup, o.Name)
-
-		err = reconcileOrgSettings(grafanaOrg, o.Name, grafanaConfig, grafanaUrl, dashboard)
-		if err != nil {
-			return err
-		}
-
-		// select with a default case is apparently the only way to do a non-blocking read from a channel
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
-			// carry on
-		}
-	}
-
-	for _, grafanaOrgToBeDeleted := range grafanaOrgLookup {
-		klog.Infof("Organization %d should not exist, deleting: '%s'", grafanaOrgToBeDeleted.ID, grafanaOrgToBeDeleted.Name)
-		err = grafanaClient.DeleteOrg(grafanaOrgToBeDeleted.ID)
-		if err != nil {
-			return err
-		}
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
-		}
-	}
-
-	klog.Infof("Reconcile complete")
-
-	return nil
 }

--- a/pkg/reconcileOrg.go
+++ b/pkg/reconcileOrg.go
@@ -1,0 +1,214 @@
+package controller
+
+import (
+	"errors"
+	grafana "github.com/grafana/grafana-api-golang-client"
+	"github.com/hashicorp/go-cleanhttp"
+	"k8s.io/klog/v2"
+	"reflect"
+	"strings"
+)
+
+func reconcileOrgSettings(org *grafana.Org, orgName string, config grafana.Config, url string, dashboard map[string]interface{}, desiredUsers []grafana.User, desiredAdmins []grafana.User) error {
+	// We can't use the grafanaClient from the overarching reconciliation loop because that client doesn't have the X-Grafana-Org-Id header set.
+	// It appears that the only way to set that header is to create a new client instance.
+	config.Client = cleanhttp.DefaultPooledClient()
+	config.OrgID = org.ID
+	grafanaClient, err := grafana.New(url, config)
+	if err != nil {
+		return err
+	}
+	defer config.Client.CloseIdleConnections()
+	dataSource, err := reconcileOrgDataSource(org, orgName, grafanaClient)
+	if err != nil {
+		return err
+	}
+	err = reconcileOrgDashboard(org, dataSource, grafanaClient, dashboard)
+	if err != nil {
+		return err
+	}
+	err = reconcileOrgUsers(org, grafanaClient, desiredUsers, desiredAdmins)
+	if err != nil {
+		return err
+	}
+	klog.Infof("Organization %d OK", org.ID)
+	return nil
+}
+
+func reconcileOrgDataSource(org *grafana.Org, orgName string, client *grafana.Client) (*grafana.DataSource, error) {
+	// If you add/remove fields here you must also adjust the 'if' statement further down
+	desiredDataSource := &grafana.DataSource{
+		Name:      "Mimir",
+		URL:       "http://vshn-appuio-mimir-query-frontend.vshn-appuio-mimir.svc.cluster.local:8080/prometheus",
+		OrgID:     org.ID, // doesn't actually do anything, we just keep it here in case it becomes relevant with some never version of the client library. The actual orgId is taken from the 'X-Grafana-Org-Id' HTTP header which is set up via grafanaConfig.OrgID
+		Type:      "prometheus",
+		IsDefault: true,
+		JSONData: map[string]interface{}{
+			"httpHeaderName1": "X-Scope-OrgID",
+			"httpMethod":      "POST",
+			"prometheusType":  "Mimir",
+		},
+		SecureJSONData: map[string]interface{}{
+			"httpHeaderValue1": orgName,
+		},
+		Access: "proxy",
+	}
+
+	var configuredDataSource *grafana.DataSource
+	configuredDataSource = nil
+	dataSources, err := client.DataSources()
+	if err != nil {
+		return nil, err
+	}
+	if len(dataSources) > 0 {
+		for _, dataSource := range dataSources {
+			if dataSource.Name == desiredDataSource.Name {
+				if dataSource.URL != desiredDataSource.URL ||
+					dataSource.Type != desiredDataSource.Type ||
+					dataSource.IsDefault != desiredDataSource.IsDefault ||
+					!reflect.DeepEqual(dataSource.JSONData, desiredDataSource.JSONData) ||
+					dataSource.Access != desiredDataSource.Access {
+					klog.Infof("Organization %d has misconfigured data source, fixing", org.ID)
+					desiredDataSource.ID = dataSource.ID
+					desiredDataSource.UID = dataSource.UID
+					err := client.UpdateDataSource(desiredDataSource)
+					if err != nil {
+						return nil, err
+					}
+					configuredDataSource = desiredDataSource
+				} else {
+					configuredDataSource = dataSource
+				}
+			} else {
+				klog.Infof("Organization %d has invalid data source %d %s, removing", org.ID, dataSource.ID, dataSource.Name)
+				client.DeleteDataSource(dataSource.ID)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	if configuredDataSource == nil {
+		klog.Infof("Organization %d missing data source, creating", org.ID)
+		dataSourceId, err := client.NewDataSource(desiredDataSource)
+		if err != nil {
+			return nil, err
+		}
+		configuredDataSource, err = client.DataSource(dataSourceId)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return configuredDataSource, nil
+}
+
+func reconcileOrgDashboard(org *grafana.Org, dataSource *grafana.DataSource, client *grafana.Client, dashboardModel map[string]interface{}) error {
+	dashboardTitle, ok := dashboardModel["title"]
+	if !ok {
+		errors.New("Invalid dashboard format: 'title' key not found")
+	}
+
+	dashboards, err := client.Dashboards()
+	if err != nil {
+		return err
+	}
+	for _, dashboard := range dashboards {
+		if dashboardTitle == dashboard.Title {
+			// Dashboard with this title already exists. We don't try to "fix" the dashboards for now, as this can cause various issues.
+			//klog.Infof("Grafana organization %d already has dashboard '%s'", org.ID, dashboardTitle)
+			return nil
+		}
+	}
+
+	err = configureDashboard(dashboardModel, dataSource)
+	if err != nil {
+		return err
+	}
+
+	dashboard := grafana.Dashboard{
+		Model:     dashboardModel,
+		Overwrite: true,
+	}
+	klog.Infof("Creating dashboard '%s' for organization %d", dashboardTitle, org.ID)
+	_, err = client.NewDashboard(dashboard)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func reconcileOrgUsers(org *grafana.Org, client *grafana.Client, desiredUsers []grafana.User, desiredAdmins []grafana.User) error {
+	orgUsers, err := client.OrgUsersCurrent()
+	if err != nil {
+		return err
+	}
+	orgUsersMap := make(map[string]grafana.OrgUser)
+	for _, orgUser := range orgUsers {
+		orgUsersMap[orgUser.Login] = orgUser
+	}
+
+	// Sync all non-admin users (viewer, editor)
+	for _, desiredUser := range desiredUsers {
+		if userListContains(desiredAdmins, desiredUser) {
+			// we'll add this user later as an admin
+			continue
+		}
+		if orgUser, ok := orgUsersMap[desiredUser.Login]; ok {
+			if !strings.EqualFold(orgUser.Role, "viewer") && !strings.EqualFold(orgUser.Role, "editor") {
+				klog.Infof("Organization %d user %s has invalid role %s, fixing", org.ID, desiredUser.Login, orgUser.Role)
+				err = client.UpdateOrgUser(org.ID, orgUser.UserID, "editor")
+				if err != nil {
+					return err
+				}
+			}
+			delete(orgUsersMap, desiredUser.Login)
+		} else {
+			klog.Infof("Organization %d user %s is missing, adding", org.ID, desiredUser.Login)
+			err = client.AddOrgUser(org.ID, desiredUser.Login, "editor")
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Sync all admin users
+	for _, desiredAdmin := range desiredAdmins {
+		if orgUser, ok := orgUsersMap[desiredAdmin.Login]; ok {
+			if !strings.EqualFold(orgUser.Role, "admin") {
+				klog.Infof("Organization %d admin %s has invalid role %s, fixing", org.ID, desiredAdmin.Login, orgUser.Role)
+				err = client.UpdateOrgUser(org.ID, orgUser.UserID, "admin")
+				if err != nil {
+					return err
+				}
+			}
+			delete(orgUsersMap, desiredAdmin.Login)
+		} else {
+			klog.Infof("Organization %d admin %s is missing, adding", org.ID, desiredAdmin.Login)
+			err = client.AddOrgUser(org.ID, desiredAdmin.Login, "admin")
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	delete(orgUsersMap, "admin") // don't delete the admin user...
+
+	for _, removeUser := range orgUsersMap {
+		klog.Infof("Organization %d user %s should not be there, removing", org.ID, removeUser.Login)
+		err = client.RemoveOrgUser(org.ID, removeUser.UserID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func userListContains(userList []grafana.User, user grafana.User) bool {
+	for _, entry := range userList {
+		if entry.ID == user.ID && entry.Login == user.Login {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/reconcileUsers.go
+++ b/pkg/reconcileUsers.go
@@ -1,0 +1,95 @@
+package controller
+
+import (
+	"crypto/rand"
+	controlapi "github.com/appuio/control-api/apis/v1"
+	grafana "github.com/grafana/grafana-api-golang-client"
+	"k8s.io/klog/v2"
+	"math/big"
+)
+
+func generatePassword() (string, error) {
+	const voc string = "abcdfghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	len := big.NewInt(int64(len(voc)))
+	pw := ""
+
+	for i := 0; i < 32; i++ {
+		index, err := rand.Int(rand.Reader, len)
+		if err != nil {
+			return "", err
+		}
+		pw = pw + string(voc[index.Uint64()])
+	}
+	return pw, nil
+}
+
+func createUser(client *grafana.Client, user controlapi.User) (*grafana.User, error) {
+	password, err := generatePassword()
+	if err != nil {
+		return nil, err
+	}
+	grafanaUser := grafana.User{
+		Email:    user.Status.Email,
+		Login:    user.Name,
+		Name:     user.Status.DisplayName,
+		Password: password,
+	}
+	grafanaUser.ID, err = client.CreateUser(grafanaUser)
+	if err != nil {
+		return nil, err
+	}
+	return &grafanaUser, nil
+}
+
+func reconcileUsers(client *grafana.Client, users map[string]controlapi.User) (map[string]grafana.User, error) {
+	grafanaUsers, err := client.Users()
+	if err != nil {
+		return nil, err
+	}
+	grafanaUsersSet := make(map[string]grafana.UserSearch)
+	for _, grafanaUser := range grafanaUsers {
+		grafanaUsersSet[grafanaUser.Login] = grafanaUser
+	}
+
+	finalGrafanaUsersMap := make(map[string]grafana.User)
+
+	for _, user := range users {
+		if grafanaUserSearch, ok := grafanaUsersSet[user.Name]; ok {
+			if grafanaUserSearch.Email != user.Status.Email ||
+				grafanaUserSearch.IsAdmin ||
+				grafanaUserSearch.Login != user.Name ||
+				grafanaUserSearch.Name != user.Status.DisplayName {
+				klog.Infof("User '%s' differs, fixing", user.Name)
+				grafanaUser := grafana.User{
+					ID:      grafanaUserSearch.ID,
+					IsAdmin: false,
+					Login:   user.Name,
+					Name:    user.Status.DisplayName,
+				}
+				client.UserUpdate(grafanaUser)
+			}
+			finalGrafanaUsersMap[grafanaUserSearch.Login] = grafana.User{ID: grafanaUserSearch.ID, Login: grafanaUserSearch.Login}
+		} else {
+			klog.Infof("User '%s' is missing, adding", user.Name)
+			grafanaUser, err := createUser(client, user)
+			if err != nil {
+				//return err
+				// for now just continue in case errors happen
+				klog.Error(err)
+				continue
+			}
+			klog.Infof("%d", grafanaUser.ID)
+			finalGrafanaUsersMap[grafanaUser.Login] = grafana.User{ID: grafanaUser.ID, Login: grafanaUser.Login}
+		}
+		klog.Infof("User '%s' OK", user.Name)
+		delete(grafanaUsersSet, user.Name)
+	}
+
+	delete(grafanaUsersSet, "admin") // don't delete the admin user...
+
+	for _, grafanaUser := range grafanaUsersSet {
+		klog.Infof("User '%s' (%d) is not in APPUiO Control API, removing", grafanaUser.Login, grafanaUser.ID)
+		client.DeleteUser(grafanaUser.ID)
+	}
+	return finalGrafanaUsersMap, nil
+}


### PR DESCRIPTION
This adds functionality to sync users and user permissions according to the information from the APPUiO Control API.

Note that a few things look a bit questionable, but not without reason:
* We need to create two k8s clients (but both use the same httpClient in the background) because one k8s client can only access one API group at a time (and we need both 'organization.appuio.io' and 'appuio.io').
* The user sync ignores some of the errors because the data in the APPUiO Control API is broken and inconsistent (in particular users don't get deleted reliably and the membership can link to deleted users). This has been reported to the APPUiO Control API developers.
* All members of organization "vshn" have admin permissions on all organizations. This is a workaround because the APPUiO Control API does not contain any information about super-/admin-users.
* We create user objects in Grafana for all Users found in the APPUiO Control API, even if they have never or will never use Grafana. This is required because we can't hand out permissions to users that don't exist in Grafana; if we didn't do that the user would only be created once he logs in, but then he wouldn't have the correct permissions right away. These users will be assigned a secure password which they'll never use (login will happen via Keycloak).